### PR TITLE
docs(community): 添加VPS/Komari 剩余价值计算器镜像站地址到在线体验链接

### DIFF
--- a/community/other.md
+++ b/community/other.md
@@ -8,4 +8,4 @@
 
 看看你的鸡还值多少钱! 一键统计所有机器价值，一键分享。
 
-在线体验: [Cloudflare Pages](https://vps-price-calculator.pages.dev/)
+在线体验: [Cloudflare Pages](https://vps-price-calculator.pages.dev/) [镜像站地址](https://vps-price-calculator.komari.wiki/)


### PR DESCRIPTION
为中国大陆用户提供更好的访问体验，在原有Cloudflare Pages链接基础上新增镜像站地址作为备用访问选项