### PR TITLE
[codex] document SDK plugin quickstart

### DIFF
--- a/dev/plugin/index.md
+++ b/dev/plugin/index.md
@@ -29,7 +29,107 @@ goja JS 运行时（沙箱），可以注册 HTTP 路由、拦截 HTTP 请求/�
 | 子进程                | `child_process`          | `allowExec`                      | 执行外部命令                                                                                     |
 | 端口监听              | `net`/`http` Server      | `allowListen`                    | 绑定本地端口（默认 `127.0.0.1`）                                                                 |
 
-## 快速开始
+## 使用 SDK 快速开始
+
+推荐使用已发布的 SDK 包和 `create-komari-plugin` 创建项目。它提供 TypeScript
+类型提示、VS Code 补全、manifest 悬停说明、本地构建，以及自动上传和热重载。
+
+### 前置条件
+
+- Node.js 20 或更高版本
+- 可以访问的 Komari 开发服务器
+- 具有安装和管理插件权限的 API Key
+- 使用 VS Code 打开生成的项目目录
+
+开发服务器地址和 API Key 属于敏感信息。创建器会将它们保存到
+`komari.local.json`，并默认加入 `.gitignore`，不要提交该文件。
+
+### 创建项目
+
+在希望创建项目的目录执行：
+
+```sh
+npm create komari-plugin hello
+```
+
+命令会交互式询问开发服务器地址和 API Key。也可以显式传参，适合脚本化创建：
+
+```sh
+npm create komari-plugin hello -- --server http://127.0.0.1:25774 --api-key "$KOMARI_API_KEY" --lang zh-CN
+```
+
+然后安装依赖并启动开发模式：
+
+```sh
+cd hello
+npm install
+npm run typecheck
+npm run dev
+```
+
+`npm run dev` 会编译 TypeScript、打包插件、上传到配置的服务器、启用插件，
+并输出插件运行时日志；同时监听源码和 manifest 的变化。文件变化后会自动重复
+这套流程。使用 `Ctrl+C` 停止监听。
+
+常用选项：
+
+```sh
+# 只执行一次构建、上传和启用
+npm run dev -- --once
+
+# 降低运行时日志轮询频率
+npm run dev -- --log-interval 1000
+
+# 关闭运行时日志转发
+npm run dev -- --no-logs
+```
+
+终端中的 `[dev:log]` 来自 Komari 的插件运行时日志缓冲区，与管理界面显示的
+插件日志相同；构建信息和 `enabled/running` 状态属于本地开发工具输出。
+
+### 生成的项目结构
+
+```text
+hello/
+├── src/plugin.ts          # TypeScript 插件源码
+├── komari-plugin.json     # 插件 manifest
+├── komari.local.json      # 本地服务器地址和 API Key，禁止提交
+├── package.json
+└── tsconfig.json
+```
+
+生成的 manifest 已引用 SDK Schema。在 VS Code 中可以获得字段补全、校验和英文
+悬停说明：
+
+```json
+{
+  "$schema": "./node_modules/@komari-monitor/plugin-sdk/schema/komari-plugin.schema.json"
+}
+```
+
+生成项目使用的 npm 包版本为 `1.4.1`。SDK 包版本与 Komari 服务端版本不要求逐个
+patch 对齐；当前 SDK 发布版本对应 Komari `1.4.x` 兼容线。manifest 的 `komari`
+字段是服务端版本约束，目前使用 `>=1.4.0` 等服务端支持的写法。
+
+### SDK 示例
+
+```ts
+import { definePlugin, jsonResponse, server } from "@komari-monitor/plugin-sdk";
+
+definePlugin({
+  load() {
+    server.route("GET", "/hello", (_req, res) => {
+      jsonResponse(res, { ok: true });
+    });
+  },
+});
+```
+
+SDK 提供带类型的 `server` 辅助 API 和 RPC catalog。已收录的方法使用
+`rpc.call()`，动态方法或插件自定义方法使用 `server.call()`。完整 API 见
+[server 模块](./server-api)和 [RPC 接口](./rpc)。
+
+## 手动 ZIP 工作流
 
 ### 1. 创建插件目录
 

--- a/en/dev/plugin/index.md
+++ b/en/dev/plugin/index.md
@@ -33,7 +33,112 @@ plugins.
 | Child processes | `child_process` | `allowExec` | Execute external commands |
 | Port listening | `net`/`http` Server | `allowListen` | Bind local ports (default `127.0.0.1`) |
 
-## Quick Start
+## Quick Start with the SDK
+
+The recommended workflow uses the published SDK packages and `create-komari-plugin`.
+It provides TypeScript types, VS Code completion, manifest hover documentation, a
+local build, and a watch mode that uploads and reloads the plugin automatically.
+
+### Prerequisites
+
+- Node.js 20 or later
+- A reachable Komari development server
+- An API key with permission to install and manage plugins
+- VS Code with the generated project opened as the workspace root
+
+Keep the development server and API key private. The initializer stores them in
+`komari.local.json`, which is added to `.gitignore` by default.
+
+### Create a project
+
+Run the initializer from the directory where the project should be created:
+
+```sh
+npm create komari-plugin hello
+```
+
+It prompts for the development server URL and API key. For scripted setup, pass
+the values explicitly:
+
+```sh
+npm create komari-plugin hello -- --server http://127.0.0.1:25774 --api-key "$KOMARI_API_KEY" --lang en
+```
+
+Then install dependencies and start development mode:
+
+```sh
+cd hello
+npm install
+npm run typecheck
+npm run dev
+```
+
+`npm run dev` builds the TypeScript source, packages the plugin, uploads it to the
+configured server, enables it, prints the runtime plugin log, and watches the
+source and manifest for changes. A file change automatically repeats that cycle.
+Use `Ctrl+C` to stop watching.
+
+Useful alternatives:
+
+```sh
+# Build, upload, and enable once
+npm run dev -- --once
+
+# Poll runtime logs less frequently
+npm run dev -- --log-interval 1000
+
+# Disable runtime log forwarding
+npm run dev -- --no-logs
+```
+
+The `[dev:log]` lines come from the same per-plugin runtime log buffer shown in
+the Komari admin UI. Build output and `enabled/running` status are local developer
+tool output, not plugin runtime logs.
+
+### Generated project layout
+
+```text
+hello/
+├── src/plugin.ts          # TypeScript plugin source
+├── komari-plugin.json     # Plugin manifest
+├── komari.local.json      # Local server URL and API key; never commit
+├── package.json
+└── tsconfig.json
+```
+
+The generated manifest references the SDK Schema. In VS Code, this enables field
+completion, validation, and English hover descriptions:
+
+```json
+{
+  "$schema": "./node_modules/@komari-monitor/plugin-sdk/schema/komari-plugin.schema.json"
+}
+```
+
+The generated project uses package version `1.4.1`. Package versions and Komari
+server versions are not required to match patch-for-patch; this SDK release tracks
+the Komari `1.4.x` compatibility line. The manifest `komari` field is a server
+version constraint and currently uses supported forms such as `>=1.4.0`.
+
+### SDK example
+
+```ts
+import { definePlugin, jsonResponse, server } from "@komari-monitor/plugin-sdk";
+
+definePlugin({
+  load() {
+    server.route("GET", "/hello", (_req, res) => {
+      jsonResponse(res, { ok: true });
+    });
+  },
+});
+```
+
+The SDK provides typed `server` helpers and a typed RPC catalog. Use `rpc.call()`
+for cataloged methods and `server.call()` for dynamic or plugin-owned methods. See
+[server Module](./server-api) and [RPC Methods](./rpc) for the complete API.
+
+## Manual ZIP Workflow
 
 ### 1. Create the plugin directory
 


### PR DESCRIPTION
## What changed

- Add Chinese and English SDK quickstart documentation.
- Document npm create komari-plugin, installation, typecheck, dev watch mode, one-shot mode, log forwarding, VS Code schema completion, permissions, and version compatibility.
- Keep the manual ZIP workflow documented separately.

## Validation

- Reviewed the generated commands and package names against the current SDK and development tool versions.